### PR TITLE
Deallocate circular references & additions to external library

### DIFF
--- a/examples/deallocation_test.rs
+++ b/examples/deallocation_test.rs
@@ -1,0 +1,36 @@
+use serde::de::Unexpected::Map;
+use hnsw_rs::dist::DistL1;
+use hnsw_rs::hnsw::Hnsw;
+
+// A test program to see if memory from insertions gets deallocated.
+// This program sets up a process that iteratively builds a new model and lets it go out of scope.
+// Since the models go out of scope, the desired behavior is that memory consumption is constant while this program is running.
+fn main() {
+    let mut counter: usize = 0;
+    loop {
+        let hnsw: Hnsw<f32, DistL1> = Hnsw::new(
+            15,
+            100_000,
+            20,
+            500_000,
+            DistL1 {}
+        );
+        let s1 = [1.0, 0.0, 0.0, 0.0];
+        hnsw.insert_slice((&s1, 0));
+        let s2 = [0.0, 1.0, 1.0];
+        hnsw.insert_slice((&s2, 1));
+        let s3 = [0.0, 0.0, 1.0];
+        hnsw.insert_slice((&s3, 2));
+        let s4 = [1.0, 0.0, 0.0, 1.0];
+        hnsw.insert_slice((&s4, 3));
+        let s5 = [1.0, 1.0, 1.0];
+        hnsw.insert_slice((&s5, 4));
+        let s6 = [1.0, -1.0, 1.0];
+        hnsw.insert_slice((&s6, 5));
+
+        if counter % 1_000_000 == 0 {
+            println!("{}", counter)
+        }
+        counter = counter + 1;
+    }
+}

--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -369,7 +369,7 @@ impl <T:Clone+Send+Sync> Drop for PointIndexation<T> {
             }
         }
 
-        // Start the recursion, if an entry point exists.
+        // If an entry point exists, start the recursion.
         match self.entry_point.write().as_ref() {
             Some(i) => {
                 clear_neighborhoods(i.as_ref().deref(), &mut HashSet::new());

--- a/src/libext.rs
+++ b/src/libext.rs
@@ -3,6 +3,7 @@
 //! The macro declare_myapi_type!  produces struct HnswApif32 and so on.
 //! 
 
+use std::alloc::{dealloc, Layout};
 use std::ptr;
 use std::fs::OpenOptions;
 use std::io::{BufReader};
@@ -371,6 +372,15 @@ pub extern "C" fn init_hnsw_f32(max_nb_conn : usize, ef_const:usize, namelen: us
     } // znd match
 } // end of init_hnsw_f32
 
+#[no_mangle]
+pub unsafe extern "C" fn drop_hnsw_f32(p: *const HnswApif32) {
+    let _raw = Box::from_raw(p as *mut HnswApif32);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn drop_hnsw_u16(p: *const HnswApiu16) {
+    let _raw = Box::from_raw(p as *mut HnswApiu16);
+}
 
 
 #[no_mangle]
@@ -559,6 +569,38 @@ pub extern "C" fn init_hnsw_u32(max_nb_conn : usize, ef_const:usize, namelen: us
     p
 } // end of init_hnsw_i32
 
+#[no_mangle]
+pub extern "C" fn new_hnsw_f32(max_nb_conn : usize, ef_const:usize, namelen: usize, cdistname : *const u8, max_elements: usize, max_layer: usize) -> *const HnswApiu32 {
+    log::debug!("entering init_hnsw_u32");
+    let  slice = unsafe { std::slice::from_raw_parts(cdistname, namelen)} ;
+    let dname = String::from_utf8_lossy(slice);
+    // map distname to sthg. This whole block will go to a macro
+    if dname == "DistL1" {
+        log::debug!(" received DistL1");
+        let h = Hnsw::<u32, DistL1 >::new(max_nb_conn, max_elements, max_layer, ef_const, DistL1{});
+        let api = HnswApiu32{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    else if dname == "DistL2" {
+        let h = Hnsw::<u32, DistL2 >::new(max_nb_conn, max_elements, max_layer, ef_const, DistL2{});
+        let api = HnswApiu32{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    else if dname == "DistJaccard" {
+        let h = Hnsw::<u32, DistJaccard >::new(max_nb_conn, max_elements, max_layer, ef_const, DistJaccard{});
+        let api = HnswApiu32{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    else if dname == "DistHamming" {
+        let h = Hnsw::<u32, DistHamming>::new(max_nb_conn, max_elements, max_layer, ef_const, DistHamming{});
+        let api = HnswApiu32{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    //
+    let p = ptr::null::< HnswApiu32 >();
+    p
+} // end of init_hnsw_i32
+
 
 
 #[no_mangle]
@@ -612,7 +654,48 @@ pub extern "C" fn init_hnsw_u16(max_nb_conn : usize, ef_const:usize, namelen: us
     else if dname == "DistJaccard" {
         let h = Hnsw::<u16, DistJaccard >::new(max_nb_conn, 10000, 16, ef_const, DistJaccard{});
         let api = HnswApiu16{opaque: Box::new(h)};
-        return Box::into_raw(Box::new(api));         
+        return Box::into_raw(Box::new(api));
+    }
+    else if dname == "DistLevenshtein" {
+        let h = Hnsw::<u16, DistLevenshtein >::new(max_nb_conn, 10000, 16, ef_const, DistLevenshtein{});
+        let api = HnswApiu16{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    let p = ptr::null::< HnswApiu16 >();
+    p
+} // end of init_hnsw_u16
+
+#[no_mangle]
+pub extern "C" fn new_hnsw_u16(max_nb_conn : usize, ef_const:usize, namelen: usize, cdistname : *const u8, max_elements: usize, max_layer: usize) -> *const HnswApiu16 {
+    log::info!("entering init_hnsw_u16");
+    let  slice = unsafe { std::slice::from_raw_parts(cdistname, namelen)} ;
+    let dname = String::from_utf8_lossy(slice);
+    // map distname to sthg. This whole block will go to a macro
+    if dname == "DistL1" {
+        log::info!(" received DistL1");
+        let h = Hnsw::<u16, DistL1 >::new(max_nb_conn, max_elements, max_layer, ef_const, DistL1{});
+        let api = HnswApiu16{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    else if dname == "DistL2" {
+        let h = Hnsw::<u16, DistL2 >::new(max_nb_conn, max_elements, max_layer, ef_const, DistL2{});
+        let api = HnswApiu16{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    else if dname == "DistHamming" {
+        let h = Hnsw::<u16, DistHamming >::new(max_nb_conn, max_elements, max_layer, ef_const, DistHamming{});
+        let api = HnswApiu16{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    else if dname == "DistJaccard" {
+        let h = Hnsw::<u16, DistJaccard >::new(max_nb_conn, max_elements, max_layer, ef_const, DistJaccard{});
+        let api = HnswApiu16{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
+    }
+    else if dname == "DistLevenshtein" {
+        let h = Hnsw::<u16, DistLevenshtein >::new(max_nb_conn, max_elements, max_layer, ef_const, DistLevenshtein{});
+        let api = HnswApiu16{opaque: Box::new(h)};
+        return Box::into_raw(Box::new(api));
     }
     let p = ptr::null::< HnswApiu16 >();
     p


### PR DESCRIPTION
@pegesund tasked me to write a java interface for this library. See here: https://bitbucket.org/sannsyn/hnsw/src/master/
This pull request is the result of that effort.

- Implemented Drop trait for PointIndexation to deallocate circular references that arise from 'point -> neighbours -> point -> ...' sequences. This is implemented for hnsw<T, D> with all T,D combinations.
- Added constructors to the external library to give max elements and max layers as arguments for hnsw_u16 and hnsw_f32.
- Added drop procedures to the external library for hnsw_u16 and hnsw_f32.
- Added Levenshtein metric as possible setting for hnsw_u16 constructors in external library.

Note that we prioritized u16 and f32 and that other types have been left untreated.
It should, however, be straight forward to implement the above changes for all cases.