### PR TITLE
Fix build failure on Windows 11

### DIFF
--- a/src/dist.rs
+++ b/src/dist.rs
@@ -970,9 +970,9 @@ impl Distance<u16> for DistLevenshtein {
 /// This type is for function with a C-API
 /// Distances can be computed by such a function. It
 /// takes as arguments the two (C, rust, julia) pointers to primitive type vectos and length 
-/// passed as a unsignedlonlong (64 bits) (which is called c_ulong in Rust!) and Culonglong in Julia
+/// passed as a unsignedlonlong (64 bits) which is called c_ulonglong in Rust and Culonglong in Julia
 /// 
-type DistCFnPtr<T> = extern "C" fn(*const T, *const T, len : c_ulong) -> f32;
+type DistCFnPtr<T> = extern "C" fn(*const T, *const T, len : c_ulonglong) -> f32;
 
 
 /// A structure to implement Distance Api for type DistCFnPtr\<T\>, 
@@ -998,7 +998,7 @@ impl <T:Copy+Clone+Sized+Send+Sync> Distance<T> for DistCFFI<T>  {
         let len = va.len();
         let ptr_a = va.as_ptr();
         let ptr_b = vb.as_ptr();
-        let dist = (self.dist_function)(ptr_a, ptr_b, len as c_ulong);
+        let dist = (self.dist_function)(ptr_a, ptr_b, len as c_ulonglong);
         log::trace!("DistCFFI dist_function_ptr {:?} returning {:?} ", self.dist_function, dist);
         dist
         } // end of compute
@@ -1239,7 +1239,7 @@ fn test_dist_ext_float() {
     let va : Vec::<f32> = vec! [1. , 2., 3.];
     let vb : Vec::<f32> = vec! [1. , 2., 3.];
     println!("in test_dist_ext_float");
-    let dist1 = dist_func_float(va.as_ptr(), vb.as_ptr(), va.len() as c_ulong);
+    let dist1 = dist_func_float(va.as_ptr(), vb.as_ptr(), va.len() as c_ulonglong);
     println!("test_dist_ext_float computed : {:?}", dist1);
 
     let mydist = DistCFFI::<f32>::new(dist_func_float);

--- a/src/libext.rs
+++ b/src/libext.rs
@@ -7,6 +7,7 @@ use std::ptr;
 use std::fs::OpenOptions;
 use std::io::{BufReader};
 use std::path::{PathBuf};
+use std::os::raw::c_ulong;
 
 use log;
 
@@ -434,7 +435,7 @@ pub unsafe extern "C" fn drop_hnsw_u16(p: *const HnswApiu16) {
 
 
 #[no_mangle]
-pub extern "C" fn init_hnsw_ptrdist_f32(max_nb_conn : usize, ef_const:usize, c_func : extern "C" fn(*const f32, *const f32, u64) -> f32 ) -> *const HnswApif32 {
+pub extern "C" fn init_hnsw_ptrdist_f32(max_nb_conn : usize, ef_const:usize, c_func : extern "C" fn(*const f32, *const f32, c_ulong) -> f32 ) -> *const HnswApif32 {
     log::info!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<f32>::new(c_func);
     let h = Hnsw::<f32, DistCFFI<f32> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);
@@ -565,7 +566,7 @@ pub extern "C" fn init_hnsw_i32(max_nb_conn : usize, ef_const:usize, namelen: us
 
 #[no_mangle]
 pub extern "C" fn init_hnsw_ptrdist_i32(max_nb_conn : usize, ef_const:usize, 
-                c_func : extern "C" fn(*const i32, *const i32, u64) -> f32 ) -> *const HnswApii32 {
+                c_func : extern "C" fn(*const i32, *const i32, c_ulong) -> f32 ) -> *const HnswApii32 {
     log::debug!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<i32>::new(c_func);
     let h = Hnsw::<i32, DistCFFI<i32> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);
@@ -624,7 +625,7 @@ pub extern "C" fn init_hnsw_u32(max_nb_conn : usize, ef_const:usize, namelen: us
 
 #[no_mangle]
 pub extern "C" fn init_hnsw_ptrdist_u32(max_nb_conn : usize, ef_const:usize, 
-                c_func : extern "C" fn(*const u32, *const u32, u64) -> f32 ) -> *const HnswApiu32 {
+                c_func : extern "C" fn(*const u32, *const u32, c_ulong) -> f32 ) -> *const HnswApiu32 {
     log::info!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<u32>::new(c_func);
     let h = Hnsw::<u32, DistCFFI<u32> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);
@@ -724,7 +725,7 @@ pub extern "C" fn new_hnsw_u16(max_nb_conn : usize, ef_const:usize, namelen: usi
 
 #[no_mangle]
 pub extern "C" fn init_hnsw_ptrdist_u16(max_nb_conn : usize, ef_const:usize, 
-                c_func : extern "C" fn(*const u16, *const u16, u64) -> f32 ) -> *const HnswApiu16 {
+                c_func : extern "C" fn(*const u16, *const u16, c_ulong) -> f32 ) -> *const HnswApiu16 {
     log::info!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<u16>::new(c_func);
     let h = Hnsw::<u16, DistCFFI<u16> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);
@@ -781,7 +782,7 @@ pub extern "C" fn init_hnsw_u8(max_nb_conn : usize, ef_const:usize, namelen: usi
 
 #[no_mangle]
 pub extern "C" fn init_hnsw_ptrdist_u8(max_nb_conn : usize, ef_const:usize, 
-                c_func : extern "C" fn(*const u8, *const u8, u64) -> f32 ) -> *const HnswApiu8 {
+                c_func : extern "C" fn(*const u8, *const u8, c_ulong) -> f32 ) -> *const HnswApiu8 {
     log::info!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<u8>::new(c_func);
     let h = Hnsw::<u8, DistCFFI<u8> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);

--- a/src/libext.rs
+++ b/src/libext.rs
@@ -7,7 +7,7 @@ use std::ptr;
 use std::fs::OpenOptions;
 use std::io::{BufReader};
 use std::path::{PathBuf};
-use std::os::raw::c_ulong;
+use std::os::raw::c_ulonglong;
 
 use log;
 
@@ -435,7 +435,7 @@ pub unsafe extern "C" fn drop_hnsw_u16(p: *const HnswApiu16) {
 
 
 #[no_mangle]
-pub extern "C" fn init_hnsw_ptrdist_f32(max_nb_conn : usize, ef_const:usize, c_func : extern "C" fn(*const f32, *const f32, c_ulong) -> f32 ) -> *const HnswApif32 {
+pub extern "C" fn init_hnsw_ptrdist_f32(max_nb_conn : usize, ef_const:usize, c_func : extern "C" fn(*const f32, *const f32, c_ulonglong) -> f32 ) -> *const HnswApif32 {
     log::info!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<f32>::new(c_func);
     let h = Hnsw::<f32, DistCFFI<f32> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);
@@ -566,7 +566,7 @@ pub extern "C" fn init_hnsw_i32(max_nb_conn : usize, ef_const:usize, namelen: us
 
 #[no_mangle]
 pub extern "C" fn init_hnsw_ptrdist_i32(max_nb_conn : usize, ef_const:usize, 
-                c_func : extern "C" fn(*const i32, *const i32, c_ulong) -> f32 ) -> *const HnswApii32 {
+                c_func : extern "C" fn(*const i32, *const i32, c_ulonglong) -> f32 ) -> *const HnswApii32 {
     log::debug!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<i32>::new(c_func);
     let h = Hnsw::<i32, DistCFFI<i32> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);
@@ -625,7 +625,7 @@ pub extern "C" fn init_hnsw_u32(max_nb_conn : usize, ef_const:usize, namelen: us
 
 #[no_mangle]
 pub extern "C" fn init_hnsw_ptrdist_u32(max_nb_conn : usize, ef_const:usize, 
-                c_func : extern "C" fn(*const u32, *const u32, c_ulong) -> f32 ) -> *const HnswApiu32 {
+                c_func : extern "C" fn(*const u32, *const u32, c_ulonglong) -> f32 ) -> *const HnswApiu32 {
     log::info!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<u32>::new(c_func);
     let h = Hnsw::<u32, DistCFFI<u32> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);
@@ -725,7 +725,7 @@ pub extern "C" fn new_hnsw_u16(max_nb_conn : usize, ef_const:usize, namelen: usi
 
 #[no_mangle]
 pub extern "C" fn init_hnsw_ptrdist_u16(max_nb_conn : usize, ef_const:usize, 
-                c_func : extern "C" fn(*const u16, *const u16, c_ulong) -> f32 ) -> *const HnswApiu16 {
+                c_func : extern "C" fn(*const u16, *const u16, c_ulonglong) -> f32 ) -> *const HnswApiu16 {
     log::info!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<u16>::new(c_func);
     let h = Hnsw::<u16, DistCFFI<u16> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);
@@ -782,7 +782,7 @@ pub extern "C" fn init_hnsw_u8(max_nb_conn : usize, ef_const:usize, namelen: usi
 
 #[no_mangle]
 pub extern "C" fn init_hnsw_ptrdist_u8(max_nb_conn : usize, ef_const:usize, 
-                c_func : extern "C" fn(*const u8, *const u8, c_ulong) -> f32 ) -> *const HnswApiu8 {
+                c_func : extern "C" fn(*const u8, *const u8, c_ulonglong) -> f32 ) -> *const HnswApiu8 {
     log::info!("init_ hnsw_ptrdist: ptr  {:?}", c_func);
     let c_dist = DistCFFI::<u8>::new(c_func);
     let h = Hnsw::<u8, DistCFFI<u8> >::new(max_nb_conn, 10000, 16, ef_const, c_dist);


### PR DESCRIPTION
While building on x64 windows 11, with x86_64 stable rust, met with an error related to trying to fit a u64 into u32. Fixed by changing the types to use `c_ulong` instead of u64.