### PR TITLE
Switch back to packed_simd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ anyhow = {version = "1.0"}
 # x86_64 simd stuff , enabled by  simdeez_f feature 
 simdeez = {version = "1.0", optional = true}
 # beta 
-packed_simd_2 = { version = "0.3", optional = true}
+packed_simd = { version = "0.3", optional = true }
 
 # for benchmark reading, so the lbrary do not depend on hdf5 nor ndarray
 [dev-dependencies]
@@ -108,4 +108,4 @@ default = []
 # simd on x86/x86_64
 simdeez_f = ["simdeez"]
 # a beta feature experimental
-stdsimd = ["packed_simd_2"]
+stdsimd = ["packed_simd"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To compile this crate on a M1 chip just do not activate this feature.
 As soon as std::simd lands in rust stable, it will be the default.
 
 * It is nevertheless possible to experiment with std::simd. Compiling with the feature stdsimd
-  (**cargo build --release --features "stdsimd"**), activates the transitory crate packed_simd_2. This requires rust nightly and also to uncomment the first line of file *lib.rs*.
+  (**cargo build --release --features "stdsimd"**), activates the transitory crate packed_simd. This requires rust nightly and also to uncomment the first line of file *lib.rs*.
   **This is discouraged** as (now) only the Hamming distance with the u32x16 and u64x8 types is provided.
 
 ### Julia interface

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -1524,7 +1524,7 @@ fn test_avx2_hamming_f64() {
 #[test]
 fn test_simd_hamming_u32() {
     init_log();
-    log::info!("testing test_simd_hamming_u32 with packed_simd_2");
+    log::info!("testing test_simd_hamming_u32 with packed_simd");
     //
     let size_test = 500;
     let imax = 3;
@@ -1554,7 +1554,7 @@ fn test_simd_hamming_u32() {
 #[test]
 fn test_simd_hamming_u64() {
     init_log();
-    log::info!("testing test_simd_hamming_u32 with packed_simd_2");
+    log::info!("testing test_simd_hamming_u32 with packed_simd");
     //
     let size_test = 500;
     let imax = 3;
@@ -1583,7 +1583,7 @@ fn test_simd_hamming_u64() {
 #[test]
 fn test_feature_simd() {
     init_log();
-    log::info!("I have activated packed_simd_2");
+    log::info!("I have activated packed_simd");
 } // end of test_feature_simd
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //#![feature(portable_simd)]
 // prededing line to uncomment to get std::simd by using
-// packed_simd_2 = { version = "0.3", optional = true}
+// packed_simd = { version = "0.3", optional = true }
 // and compile with cargo [test|build] --features "stdsimd" ...
 
 // for logging (debug mostly, switched at compile time in cargo.toml)


### PR DESCRIPTION
packed_simd is now again being published under its original name.