### PR TITLE
use a different allocator too boost performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ anyhow = { version = "1.0" }
 #anndists = { path = "../anndists" }
 #anndist = { version = "0.1.2" }
 anndists = { git = "https://github.com/jean-pierreBoth/anndists" }
-
+mimalloc = { version = "0.1.42" }
 # for benchmark reading, so the lbrary do not depend on hdf5 nor ndarray
 [dev-dependencies]
 hdf5 = { version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ anyhow = { version = "1.0" }
 #anndists = { path = "../anndists" }
 #anndist = { version = "0.1.2" }
 anndists = { git = "https://github.com/jean-pierreBoth/anndists" }
-mimalloc = { version = "0.1.42" }
+mimalloc = { version = "0.1.42", optional = true }
 # for benchmark reading, so the lbrary do not depend on hdf5 nor ndarray
 [dev-dependencies]
 hdf5 = { version = "0.8" }
@@ -101,7 +101,10 @@ skiplist = { version = "0.5" }
 
 default = []
 
+# feature for std simd on nightly
 stdsimd = ["anndists/stdsimd"]
 # feature for simd on stable for x86*
 simdeez_f = ["anndists/simdeez_f"]
-# feature for std simd on nightly
+
+# microsoft malloc, performance improvement
+mimalloc = ["mimalloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,4 +107,4 @@ stdsimd = ["anndists/stdsimd"]
 simdeez_f = ["anndists/simdeez_f"]
 
 # microsoft malloc, performance improvement
-mimalloc = ["mimalloc"]
+use_mimalloc = ["mimalloc"]

--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -27,10 +27,14 @@ use log::trace;
 
 pub use crate::filter::FilterT;
 use anndists::dist::distances::Distance;
+
+#[cfg(feature = "mimalloc")]
 use mimalloc::MiMalloc;
 
+#[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
+
 // TODO
 // Profiling.
 

--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -28,10 +28,10 @@ use log::trace;
 pub use crate::filter::FilterT;
 use anndists::dist::distances::Distance;
 
-#[cfg(feature = "mimalloc")]
+#[cfg(feature = "use_mimalloc")]
 use mimalloc::MiMalloc;
 
-#[cfg(feature = "mimalloc")]
+#[cfg(feature = "use_mimalloc")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 

--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -27,7 +27,10 @@ use log::trace;
 
 pub use crate::filter::FilterT;
 use anndists::dist::distances::Distance;
+use mimalloc::MiMalloc;
 
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 // TODO
 // Profiling.
 


### PR DESCRIPTION
Hello Jean,

I recently learned that we can use a different allocator like the mimalloc (https://www.microsoft.com/en-us/research/uploads/prod/2019/06/mimalloc-tr-v1.pdf). I saw about 10% improvement using the sift 1M testing dataset. Not sure whehter we should make the mimalloc available to users but I just want you to know about this. Below is my benchmark results:

Let me know if this makes sense. I have it as a feature.

Thanks,
Jianshu

```bash
Mimalloc and libc malloc Rust hnswlib-rs test
Mimalloc:

neighbours shape : [10000, 100]

 10 first neighbours for first vector : 
 932085  934876  561813  708177  706771  695756  435345  701258  455537  872728 
 10 first neighbours for second vector : 
 413247  413071  706838  880592  249062  400194  942339  880462  987636  941776  test data, nb element 10000,  dim : 128

 train data shape : [1000000, 128], nbvector 1000000 
 allocating vector for search neighbours answer : 10000
 number of elements to insert 1000000 , setting max nb layer to 13 ef_construction 1600
 =====================================================================================
 
 parallel insertion
 setting number of points 50000 
 setting number of points 100000 
 setting number of points 150000 
 setting number of points 200000 
 setting number of points 250000 
 setting number of points 300000 
 setting number of points 350000 
 setting number of points 400000 
 setting number of points 450000 
 setting number of points 500000 
 setting number of points 550000 
 setting number of points 600000 
 setting number of points 650000 
 setting number of points 700000 
 setting number of points 750000 
 setting number of points 800000 
 setting number of points 850000 
 setting number of points 900000 
 setting number of points 950000 
 setting number of points 1000000 

 hnsw data insertion cpu time  128931.087617675s  system time Ok(2015.446201584s) 
 debug dump of PointIndexation
 layer 0 : length : 984372 
 layer 1 : length : 15381 
 layer 2 : length : 246 
 layer 3 : length : 1 
 debug dump of PointIndexation end
 hnsw data nb point inserted 1000000
searching with ef = 64


 ef_search : 64 knbn : 10 
searching with ef : 64
 
 parallel search
total cpu time for search requests 102552810.0 , system time Ok(1.619707252s) 

 mean fraction nb returned by search 1.0 

 last distances ratio 1.0003893 

 recall rate for "/storage/home/hcoda1/4/jzhao399/p-ktk3-0/rich_project_bio-konstantinidis/apps/gsearch_new/ANN_data/sift1m-128-euclidean.hdf5" is 0.99014 , nb req /s 6173.956
searching with ef = 64


 ef_search : 128 knbn : 10 
searching with ef : 128
 
 parallel search
total cpu time for search requests 183107950.0 , system time Ok(2.883226225s) 

 mean fraction nb returned by search 1.0 

 last distances ratio 1.0001731 

 recall rate for "/storage/home/hcoda1/4/jzhao399/p-ktk3-0/rich_project_bio-konstantinidis/apps/gsearch_new/ANN_data/sift1m-128-euclidean.hdf5" is 0.99626 , nb req /s 3468.3384




Libc malloc (Rust default malloc):


neighbours shape : [10000, 100]

 10 first neighbours for first vector : 
 932085  934876  561813  708177  706771  695756  435345  701258  455537  872728 
 10 first neighbours for second vector : 
 413247  413071  706838  880592  249062  400194  942339  880462  987636  941776  test data, nb element 10000,  dim : 128

 train data shape : [1000000, 128], nbvector 1000000 
 allocating vector for search neighbours answer : 10000
 number of elements to insert 1000000 , setting max nb layer to 13 ef_construction 1600
 =====================================================================================
 
 parallel insertion
 setting number of points 50000 
 setting number of points 100000 
 setting number of points 150000 
 setting number of points 200000 
 setting number of points 250000 
 setting number of points 300000 
 setting number of points 350000 
 setting number of points 400000 
 setting number of points 450000 
 setting number of points 500000 
 setting number of points 550000 
 setting number of points 600000 
 setting number of points 650000 
 setting number of points 700000 
 setting number of points 750000 
 setting number of points 800000 
 setting number of points 850000 
 setting number of points 900000 
 setting number of points 950000 
 setting number of points 1000000 

 hnsw data insertion cpu time  135256.668361233s  system time Ok(2114.099762023s) 
 debug dump of PointIndexation
 layer 0 : length : 984340 
 layer 1 : length : 15437 
 layer 2 : length : 221 
 layer 3 : length : 2 
 debug dump of PointIndexation end
 hnsw data nb point inserted 1000000
searching with ef = 64


 ef_search : 64 knbn : 10 
searching with ef : 64
 
 parallel search
total cpu time for search requests 111934620.0 , system time Ok(1.771543603s) 

 mean fraction nb returned by search 1.0 

 last distances ratio 1.0003972 

 recall rate for "/storage/home/hcoda1/4/jzhao399/p-ktk3-0/rich_project_bio-konstantinidis/apps/gsearch_new/ANN_data/sift1m-128-euclidean.hdf5" is 0.9905 , nb req /s 5644.797
searching with ef = 64


 ef_search : 128 knbn : 10 
searching with ef : 128
 
 parallel search
total cpu time for search requests 198955360.0 , system time Ok(3.138830114s) 

 mean fraction nb returned by search 1.0 

 last distances ratio 1.0001935 

 recall rate for "/storage/home/hcoda1/4/jzhao399/p-ktk3-0/rich_project_bio-konstantinidis/apps/gsearch_new/ANN_data/sift1m-128-euclidean.hdf5" is 0.99604 , nb req /s 3185.9016
```