### PR TITLE
implemented flush method

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,6 @@
 //! Api for external language.  
 //! This file provides a trait to be used as an opaque pointer for C or Julia calls used in file libext.rs
 
-use std::io::prelude::*;
 use std::path::PathBuf;
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -81,15 +80,8 @@ where
         //
         let res = self.dump(DumpMode::Full, &mut dumpinit);
         //
-        let outgraph = &mut dumpinit.graph_out;
-        let outdata = &mut dumpinit.data_out;
-        outgraph.flush().unwrap();
-        outdata.flush().unwrap();
-        //
-        drop(dumpinit.graph_out);
-        drop(dumpinit.data_out);
-        //
-        log::info!("\n end of dump");
+        dumpinit.flush()?;
+        log::info!("end of dump");
         if res.is_ok() {
             return Ok(dumpname);
         } else {

--- a/src/hnswio.rs
+++ b/src/hnswio.rs
@@ -238,6 +238,12 @@ impl DumpInit {
     pub fn get_basename(&self) -> &String {
         &self.basename
     }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.data_out.flush()?;
+        self.graph_out.flush()?;
+        Ok(())
+    }
 } // end impl for DumpInit
 
 //====================================================


### PR DESCRIPTION
The current implementation of file_dump is too constrained with the directory, etc. To avoid the API changes, I implemented the flush method for DumpInit, which must be sufficient to implement custom savers.