### PR TITLE
Migrate from deprecated `mmap-rs` to actively maintained `memmap2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rand = { version = "0.8" }
 lazy_static = { version = "1.4" }
 
 #
-mmap-rs = { version = "0.6" }
+memmap2 = { version = "0.9" }
 #
 # decreasing order of log for debug build : (max_level_)trace debug info warn error off
 # decreasing order of log for release build (release_max_level_)  .. idem

--- a/src/datamap.rs
+++ b/src/datamap.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 
 use indexmap::map::IndexMap;
 use log::{debug, error, info, trace};
-use mmap_rs::{Mmap, MmapOptions};
+use memmap2::{Mmap, MmapOptions};
 
 use crate::hnsw::DataId;
 use crate::hnswio;
@@ -96,19 +96,13 @@ impl DataMap {
             error!("Could not open file : {:?}", &datapath);
             std::process::exit(1);
         }
-        let fsize = meta.unwrap().len().try_into().unwrap();
-        //
         let file_res = File::open(&datapath);
         if file_res.is_err() {
             error!("Could not open file : {:?}", &datapath);
             std::process::exit(1);
         }
         let file = file_res.unwrap();
-        let offset = 0;
-        //
-        let mmap_opt = MmapOptions::new(fsize).unwrap();
-        let mmap_opt = unsafe { mmap_opt.with_file(&file, offset) };
-        let mapping_res = mmap_opt.map();
+        let mapping_res = unsafe { MmapOptions::new().map(&file) };
         if mapping_res.is_err() {
             error!("Could not memory map : {:?}", &datapath);
             std::process::exit(1);
@@ -119,7 +113,7 @@ impl DataMap {
         //
         // where are we in decoding mmap slice? at beginning
         //
-        let mapped_slice = mmap.as_slice();
+        let mapped_slice = &mmap[..];
         //
         // where are we in decoding mmap slice?
         let mut current_mmap_addr = 0usize;
@@ -153,10 +147,10 @@ impl DataMap {
         let record_size = std::mem::size_of::<u32>()
             + 2 * std::mem::size_of::<u64>()
             + dimension * std::mem::size_of::<T>();
-        let residual = mmap.size() - current_mmap_addr;
+        let residual = mmap.len() - current_mmap_addr;
         info!(
             "Mmap size {}, current_mmap_addr {}, residual : {}",
-            mmap.size(),
+            mmap.len(),
             current_mmap_addr,
             residual
         );
@@ -275,7 +269,7 @@ impl DataMap {
         let address = self.hmap.get(dataid)?;
         debug!("Address for id : {}, address : {:?}", dataid, address);
         let mut current_mmap_addr = *address;
-        let mapped_slice = self.mmap.as_slice();
+        let mapped_slice = &self.mmap[..];
         let mut u64_slice = [0u8; std::mem::size_of::<u64>()];
         u64_slice.copy_from_slice(
             &mapped_slice[current_mmap_addr..current_mmap_addr + std::mem::size_of::<u64>()],
@@ -285,7 +279,7 @@ impl DataMap {
         trace!("Serialized bytes len to reload {:?}", serialized_len);
         let slice_t = unsafe {
             std::slice::from_raw_parts(
-                mapped_slice[current_mmap_addr..].as_ptr() as *const T,
+                self.mmap[current_mmap_addr..].as_ptr() as *const T,
                 self.dimension,
             )
         };
@@ -327,6 +321,7 @@ mod tests {
 
     pub use crate::api::AnnT;
     use crate::prelude::*;
+    use crate::tests::test_utils::check_graph_equality;
 
     use rand::distributions::{Distribution, Uniform};
 
@@ -368,11 +363,10 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let _res = hnsw.file_dump(directory.path(), fname);
 
-        let check_reload = false;
+        let check_reload = true;
         if check_reload {
             // We check we can reload
             debug!("HNSW reload.");
-            let directory = tempfile::tempdir().unwrap();
             let mut reloader = HnswIo::new(directory.path(), fname);
             let hnsw_loaded: Hnsw<f32, DistL1> = reloader.load_hnsw::<f32, DistL1>().unwrap();
             check_graph_equality(&hnsw_loaded, &hnsw);
@@ -445,8 +439,13 @@ mod tests {
             assert_eq!(v, &data[*dataid], "dataid = {}, ukey = {}", dataid, i);
         }
         // rm files generated!
-        let _ = std::fs::remove_file("mmap_order_test.hnsw.data");
-        let _ = std::fs::remove_file("mmap_order_test.hnsw.graph");
+        let mut data_path = directory.path().to_path_buf();
+        data_path.push("mmap_order_test.hnsw.data");
+        let _ = std::fs::remove_file(data_path);
+
+        let mut graph_path = directory.path().to_path_buf();
+        graph_path.push("mmap_order_test.hnsw.graph");
+        let _ = std::fs::remove_file(graph_path);
     }
     //
 } // end of mod tests


### PR DESCRIPTION
This PR replaces the deprecated `mmap-rs` dependency with its maintained successor `memmap2` which is more actively maintained and more secure.

The migration was tested to build on my x86_64 and loongarch64 devices with Arch Linux.
