### PR TITLE
add cosine and some minor fix

### DIFF
--- a/tests/equality.rs
+++ b/tests/equality.rs
@@ -1,10 +1,12 @@
 /*
  check retrieve of data with query being the inserted data
 
- playing with parameters we can see that:
-  - parallel (versus serial) insertion can degrade performance. Pb is more acute with DistL1 than DistJaccard
-  - degradation reduces when using modify_level_scale
-  - BUT it can also occur that parallel insertion has better recall than serial
+ Notes:
+  - For a fair parallel/serial comparison, both indexes must use the same parameters,
+    including modify_level_scale when it is used.
+  - After building the serial index, search must be recomputed on the serial index.
+  - Long neighbour dumps for missing self-retrieval are logged at debug level.
+  - Info level only prints compact summaries.
 */
 
 use anndists::dist::*;
@@ -13,177 +15,322 @@ use cpu_time::ProcessTime;
 use hnsw_rs::prelude::*;
 use rand::distr::{Distribution, Uniform};
 
+#[derive(Debug, Clone)]
+struct SearchStats {
+    nb_found: usize,
+    nb_dist_equal: usize,
+    missing_ids: Vec<usize>,
+}
+
+fn report_search_results<T: std::fmt::Debug>(
+    label: &str,
+    data_neighbours: &[Vec<Neighbour>],
+    epsil: f32,
+) -> SearchStats {
+    let mut nb_found = 0usize;
+    let mut nb_dist_equal = 0usize;
+    let mut missing_ids = Vec::new();
+
+    for (id, neighbours) in data_neighbours.iter().enumerate() {
+        let mut found_id = false;
+
+        for neighbour in neighbours {
+            if neighbour.get_distance() <= epsil {
+                nb_dist_equal += 1;
+            }
+
+            if neighbour.get_origin_id() == id {
+                found_id = true;
+                nb_found += 1;
+            }
+        }
+
+        if !found_id {
+            missing_ids.push(id);
+        }
+    }
+
+    log::info!(
+        "{} : nb_found = {}, nb_dist_equal = {:.5e}, missing_count = {}",
+        label,
+        nb_found,
+        nb_dist_equal,
+        missing_ids.len()
+    );
+
+    if !missing_ids.is_empty() {
+        log::info!("{} : missing_ids = {:?}", label, missing_ids);
+    }
+
+    for id in &missing_ids {
+        log::debug!(
+            "{} missing id = {}, neighbours = {:?}",
+            label,
+            id,
+            data_neighbours[*id]
+        );
+    }
+
+    SearchStats {
+        nb_found,
+        nb_dist_equal,
+        missing_ids,
+    }
+}
+
 #[test]
 fn test_equality_float() {
-    //
     let _ = env_logger::builder().is_test(true).try_init();
-    //
-    println!("\n\n test_equality_retrieve");
-    //
+
+    println!("\n\n test_equality_float");
+
     let mut rng = rand::rng();
     let unif = Uniform::<f32>::new(0., 1.).unwrap();
+
     let nbdata = 10000;
     let dim = 10;
+
     let mut datas: Vec<Vec<f32>> = Vec::with_capacity(nbdata);
-    //
+
     for _ in 0..nbdata {
         datas.push(
             (0..dim)
                 .map(|_| unif.sample(&mut rng))
                 .collect::<Vec<f32>>(),
         );
-        // data_refs.push((&datas[j], j));
     }
+
     let data_refs: Vec<(&Vec<f32>, usize)> = (0..nbdata).map(|j| (&datas[j], j)).collect();
-    // insertion
+
     let ef_construct = 128;
     let nb_connection = 32;
-    let _start = ProcessTime::now();
-    let mut hns = Hnsw::<f32, DistL1>::new(nb_connection, nbdata, 16, ef_construct, DistL1 {});
-    hns.modify_level_scale(0.5);
+    let max_layer = 16;
+    let search_ef = 1024;
+    let search_k = 16;
+    let epsil = 1.0E-5;
 
+    //
     // parallel insertion
+    //
+    log::info!("running DistL1 parallel insertion");
+
+    let _start = ProcessTime::now();
+
+    let mut hns =
+        Hnsw::<f32, DistL1>::new(nb_connection, nbdata, max_layer, ef_construct, DistL1 {});
+
+    hns.modify_level_scale(0.5);
     hns.parallel_insert(&data_refs);
     hns.dump_layer_info();
-    //
-    // check how many we retrieve each data in a neighborhood
-    //
-    let data_neighbours = hns.parallel_search(&datas, 16, 16);
+
+    let data_neighbours = hns.parallel_search(&datas, search_k, search_ef);
     assert_eq!(data_neighbours.len(), nbdata);
 
-    let epsil = 1.0E-5;
-    let mut nb_found = 0usize;
-    let mut nb_dist_equal = 0;
-    for (id, neighbours) in data_neighbours.iter().enumerate() {
-        for neighbour in neighbours {
-            if neighbour.get_distance() <= epsil {
-                nb_dist_equal += 1;
-            }
-            if neighbour.get_origin_id() == id {
-                nb_found += 1;
-            }
-        }
-    }
-    //
-    log::info!(
-        "DistL1 parallel insertion : nb_found = {}, nb_dist_equal = {:.4e}",
-        nb_found,
-        nb_dist_equal
-    );
+    let parallel_stats =
+        report_search_results::<f32>("DistL1 parallel insertion", &data_neighbours, epsil);
+
     //
     // serial insertion
     //
-    log::info!("running serial insertion");
-    let hns = Hnsw::<f32, DistL1>::new(nb_connection, nbdata, 16, ef_construct, DistL1 {});
+    log::info!("running DistL1 serial insertion");
+
+    let mut hns =
+        Hnsw::<f32, DistL1>::new(nb_connection, nbdata, max_layer, ef_construct, DistL1 {});
+
+    hns.modify_level_scale(0.5);
+
     for data in data_refs {
         hns.insert((data.0, data.1));
     }
-    let data_neighbours = hns.parallel_search(&datas, 16, 16);
+
+    let data_neighbours = hns.parallel_search(&datas, search_k, search_ef);
     assert_eq!(data_neighbours.len(), nbdata);
-    let mut nb_found = 0usize;
-    let mut nb_dist_equal = 0;
-    for (id, neighbours) in data_neighbours.iter().enumerate() {
-        for neighbour in neighbours {
-            if neighbour.get_distance() <= epsil {
-                nb_dist_equal += 1;
-                if neighbour.get_origin_id() == id {
-                    nb_found += 1;
-                }
-            }
-        }
-    }
-    //
+
+    let serial_stats =
+        report_search_results::<f32>("DistL1 serial insertion", &data_neighbours, epsil);
+
     log::info!(
-        "\n\n DistL1 serial insertion : nb_found = {}, nb_dist_equal = {:.4e}",
-        nb_found,
-        nb_dist_equal
+        "DistL1 comparison : parallel_found = {}, serial_found = {}, parallel_missing = {}, serial_missing = {}",
+        parallel_stats.nb_found,
+        serial_stats.nb_found,
+        parallel_stats.missing_ids.len(),
+        serial_stats.missing_ids.len()
+    );
+}
+
+#[test]
+fn test_equality_cosine() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    println!("\n\n test_equality_cosine");
+
+    let mut rng = rand::rng();
+    let unif = Uniform::<f32>::new(0., 1.).unwrap();
+
+    let nbdata = 10000;
+    let dim = 10;
+
+    let mut datas: Vec<Vec<f32>> = Vec::with_capacity(nbdata);
+
+    for _ in 0..nbdata {
+        datas.push(
+            (0..dim)
+                .map(|_| unif.sample(&mut rng))
+                .collect::<Vec<f32>>(),
+        );
+    }
+
+    let data_refs: Vec<(&Vec<f32>, usize)> = (0..nbdata).map(|j| (&datas[j], j)).collect();
+
+    let ef_construct = 128;
+    let nb_connection = 32;
+    let max_layer = 16;
+    let search_ef = 1024;
+    let search_k = 16;
+    let epsil = 1.0E-5;
+
+    //
+    // parallel insertion
+    //
+    log::info!("running DistCosine parallel insertion");
+
+    let _start = ProcessTime::now();
+
+    let mut hns = Hnsw::<f32, DistCosine>::new(
+        nb_connection,
+        nbdata,
+        max_layer,
+        ef_construct,
+        DistCosine {},
+    );
+
+    hns.modify_level_scale(0.5);
+    hns.parallel_insert(&data_refs);
+    hns.dump_layer_info();
+
+    let data_neighbours = hns.parallel_search(&datas, search_k, search_ef);
+    assert_eq!(data_neighbours.len(), nbdata);
+
+    let parallel_stats =
+        report_search_results::<f32>("DistCosine parallel insertion", &data_neighbours, epsil);
+
+    //
+    // serial insertion
+    //
+    log::info!("running DistCosine serial insertion");
+
+    let mut hns = Hnsw::<f32, DistCosine>::new(
+        nb_connection,
+        nbdata,
+        max_layer,
+        ef_construct,
+        DistCosine {},
+    );
+
+    hns.modify_level_scale(0.5);
+
+    for data in data_refs {
+        hns.insert((data.0, data.1));
+    }
+
+    let data_neighbours = hns.parallel_search(&datas, search_k, search_ef);
+    assert_eq!(data_neighbours.len(), nbdata);
+
+    let serial_stats =
+        report_search_results::<f32>("DistCosine serial insertion", &data_neighbours, epsil);
+
+    log::info!(
+        "DistCosine comparison : parallel_found = {}, serial_found = {}, parallel_missing = {}, serial_missing = {}",
+        parallel_stats.nb_found,
+        serial_stats.nb_found,
+        parallel_stats.missing_ids.len(),
+        serial_stats.missing_ids.len()
     );
 }
 
 #[test]
 fn test_equality_int() {
-    //
     let _ = env_logger::builder().is_test(true).try_init();
-    //
-    println!("\n\n test_equality_retrieve");
-    //
+
+    println!("\n\n test_equality_int");
+
     let mut rng = rand::rng();
     let unif = Uniform::<u32>::new(0, 1000).unwrap();
+
     let nbdata = 10000;
     let dim = 10;
+
     let mut datas: Vec<Vec<u32>> = Vec::with_capacity(nbdata);
-    //
+
     for _ in 0..nbdata {
         datas.push(
             (0..dim)
                 .map(|_| unif.sample(&mut rng))
                 .collect::<Vec<u32>>(),
         );
-        // data_refs.push((&datas[j], j));
     }
+
     let data_refs: Vec<(&Vec<u32>, usize)> = (0..nbdata).map(|j| (&datas[j], j)).collect();
-    // insertion
-    let ef_construct = 32;
-    let nb_connection = 16;
-    let _start = ProcessTime::now();
-    #[allow(unused_mut)]
-    let mut hns =
-        Hnsw::<u32, DistJaccard>::new(nb_connection, nbdata, 16, ef_construct, DistJaccard {});
-    //    hns.modify_level_scale(0.5);
+
+    let ef_construct = 128;
+    let nb_connection = 32;
+    let max_layer = 16;
+    let search_ef = 1024;
+    let search_k = 16;
+    let epsil = 1.0E-5;
+
+    //
     // parallel insertion
+    //
+    log::info!("running DistJaccard parallel insertion");
+
+    let _start = ProcessTime::now();
+
+    let hns = Hnsw::<u32, DistJaccard>::new(
+        nb_connection,
+        nbdata,
+        max_layer,
+        ef_construct,
+        DistJaccard {},
+    );
+
     hns.parallel_insert(&data_refs);
     hns.dump_layer_info();
 
-    //
-    // check how many we retrieve each data in a neighborhood
-    //
-    let data_neighbours = hns.parallel_search(&datas, 16, 16);
+    let data_neighbours = hns.parallel_search(&datas, search_k, search_ef);
     assert_eq!(data_neighbours.len(), nbdata);
 
-    let epsil = 1.0E-5;
-    let mut nb_found = 0usize;
-    let mut nb_dist_equal = 0;
-    for (id, neighbours) in data_neighbours.iter().enumerate() {
-        for neighbour in neighbours {
-            if neighbour.get_distance() <= epsil {
-                nb_dist_equal += 1;
-            }
-            if neighbour.get_origin_id() == id {
-                nb_found += 1;
-            }
-        }
-    }
-    //
-    log::info!(
-        "DistJaccard parallel insertion : nb_found = {}, nb_dist_equal = {:.5e}",
-        nb_found,
-        nb_dist_equal
-    );
+    let parallel_stats =
+        report_search_results::<u32>("DistJaccard parallel insertion", &data_neighbours, epsil);
+
     //
     // serial insertion
     //
-    log::info!("running serial insertion");
-    let hns =
-        Hnsw::<u32, DistJaccard>::new(nb_connection, nbdata, 16, ef_construct, DistJaccard {});
+    log::info!("running DistJaccard serial insertion");
+
+    let hns = Hnsw::<u32, DistJaccard>::new(
+        nb_connection,
+        nbdata,
+        max_layer,
+        ef_construct,
+        DistJaccard {},
+    );
+
     for data in data_refs {
         hns.insert((data.0, data.1));
     }
-    let mut nb_found = 0usize;
-    let mut nb_dist_equal = 0;
-    for (id, neighbours) in data_neighbours.iter().enumerate() {
-        for neighbour in neighbours {
-            if neighbour.get_distance() <= epsil {
-                nb_dist_equal += 1;
-                if neighbour.get_origin_id() == id {
-                    nb_found += 1;
-                }
-            }
-        }
-    }
-    //
+
+    let data_neighbours = hns.parallel_search(&datas, search_k, search_ef);
+    assert_eq!(data_neighbours.len(), nbdata);
+
+    let serial_stats =
+        report_search_results::<u32>("DistJaccard serial insertion", &data_neighbours, epsil);
+
     log::info!(
-        "\n\n DistJaccard serial insertion : nb_found = {}, nb_dist_equal = {:.5e}",
-        nb_found,
-        nb_dist_equal
+        "DistJaccard comparison : parallel_found = {}, serial_found = {}, parallel_missing = {}, serial_missing = {}",
+        parallel_stats.nb_found,
+        serial_stats.nb_found,
+        parallel_stats.missing_ids.len(),
+        serial_stats.missing_ids.len()
     );
 }


### PR DESCRIPTION
let me know you thoughts, this is the test results I have: 

```bash
$ RUST_LOG=info cargo test --features stdsimd --test equality -- --nocapture
warning: feature `portable_simd` is declared but not used
 --> src/lib.rs:1:42
  |
1 | #![cfg_attr(feature = "stdsimd", feature(portable_simd))]
  |                                          ^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default

warning: `hnsw_rs` (lib) generated 1 warning
   Compiling hnsw_rs v0.3.4 (/Users/jianshuzhao/hnswlib-rs)
warning: field `nb_dist_equal` is never read
  --> tests/equality.rs:21:5
   |
19 | struct SearchStats {
   |        ----------- field in this struct
20 |     nb_found: usize,
21 |     nb_dist_equal: usize,
   |     ^^^^^^^^^^^^^
   |
   = note: `SearchStats` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: `hnsw_rs` (test "equality") generated 1 warning
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.19s
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running tests/equality.rs (target/debug/deps/equality-8a6c5ae1502a037e)

running 3 tests


 test_equality_cosine


 test_equality_int


 test_equality_float
[2026-06-16T00:50:34Z INFO  equality] running DistCosine parallel insertion
[2026-06-16T00:50:34Z INFO  equality] running DistJaccard parallel insertion
[2026-06-16T00:50:34Z INFO  equality] running DistL1 parallel insertion
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw max_nb_connection 32
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw max_nb_connection 32
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw max_nb_connection 32
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw nb elements 10000
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw nb elements 10000
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw nb elements 10000
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw ef_construction 128
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw ef_construction 128
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw ef_construction 128
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw distance "anndists::dist::distances::DistJaccard"
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw distance "anndists::dist::distances::DistCosine"
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw distance "anndists::dist::distances::DistL1"
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw extend candidates false
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw extend candidates false
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] Hnsw extend candidates false

  Current scale value : 2.89e-1, Scale modification factor asked : 5.00e-1,(modification factor must be between 2.00e-1 and 1.)
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] using scale for sampling levels : 1.44e-1

  Current scale value : 2.89e-1, Scale modification factor asked : 5.00e-1,(modification factor must be between 2.00e-1 and 1.)
[2026-06-16T00:50:34Z INFO  hnsw_rs::hnsw] using scale for sampling levels : 1.44e-1
 debug dump of PointIndexation
 debug dump of PointIndexation
 debug dump of PointIndexation
 layer 0 : length : 9991 
 layer 1 : length : 9 
 debug dump of PointIndexation end
 layer 0 : length : 9694 
 layer 1 : length : 297 
 layer 2 : length : 9 
 debug dump of PointIndexation end
 layer 0 : length : 9991 
 layer 1 : length : 9 
 debug dump of PointIndexation end
[2026-06-16T00:51:01Z INFO  equality] DistCosine parallel insertion : nb_found = 10000, nb_dist_equal = 1.00000e4, missing_count = 0
[2026-06-16T00:51:01Z INFO  equality] running DistCosine serial insertion
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw max_nb_connection 32
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw nb elements 10000
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw ef_construction 128
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw distance "anndists::dist::distances::DistCosine"
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw extend candidates false

  Current scale value : 2.89e-1, Scale modification factor asked : 5.00e-1,(modification factor must be between 2.00e-1 and 1.)
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] using scale for sampling levels : 1.44e-1
[2026-06-16T00:51:01Z INFO  equality] DistL1 parallel insertion : nb_found = 10000, nb_dist_equal = 1.00000e4, missing_count = 0
[2026-06-16T00:51:01Z INFO  equality] running DistL1 serial insertion
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw max_nb_connection 32
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw nb elements 10000
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw ef_construction 128
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw distance "anndists::dist::distances::DistL1"
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw extend candidates false

  Current scale value : 2.89e-1, Scale modification factor asked : 5.00e-1,(modification factor must be between 2.00e-1 and 1.)
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] using scale for sampling levels : 1.44e-1
[2026-06-16T00:51:01Z INFO  equality] DistJaccard parallel insertion : nb_found = 9953, nb_dist_equal = 9.95300e3, missing_count = 47
[2026-06-16T00:51:01Z INFO  equality] DistJaccard parallel insertion : missing_ids = [942, 1079, 1085, 1091, 2445, 3005, 3408, 3719, 3726, 3745, 4357, 5523, 5760, 5801, 5857, 6102, 6134, 6140, 6154, 6185, 6186, 6777, 6894, 6973, 7000, 7018, 7032, 7091, 7163, 7177, 7193, 7278, 7291, 7337, 7352, 7361, 7425, 8348, 8431, 8474, 8509, 8519, 8585, 8602, 8665, 8749, 9683]
[2026-06-16T00:51:01Z INFO  equality] running DistJaccard serial insertion
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw max_nb_connection 32
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw nb elements 10000
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw ef_construction 128
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw distance "anndists::dist::distances::DistJaccard"
[2026-06-16T00:51:01Z INFO  hnsw_rs::hnsw] Hnsw extend candidates false
test test_equality_cosine has been running for over 60 seconds
test test_equality_float has been running for over 60 seconds
test test_equality_int has been running for over 60 seconds
[2026-06-16T00:51:38Z INFO  equality] DistJaccard serial insertion : nb_found = 9959, nb_dist_equal = 9.95900e3, missing_count = 41
[2026-06-16T00:51:38Z INFO  equality] DistCosine serial insertion : nb_found = 10000, nb_dist_equal = 1.00000e4, missing_count = 0
[2026-06-16T00:51:38Z INFO  equality] DistJaccard serial insertion : missing_ids = [4036, 6116, 6297, 7431, 7853, 8006, 8067, 8146, 8252, 8557, 8599, 8623, 8629, 8678, 8781, 8928, 8959, 8968, 8991, 8998, 9017, 9040, 9043, 9044, 9064, 9103, 9166, 9259, 9288, 9442, 9466, 9480, 9671, 9718, 9733, 9747, 9763, 9818, 9856, 9883, 9897]
[2026-06-16T00:51:38Z INFO  equality] DistCosine comparison : parallel_found = 10000, serial_found = 10000, parallel_missing = 0, serial_missing = 0
[2026-06-16T00:51:38Z INFO  equality] DistJaccard comparison : parallel_found = 9953, serial_found = 9959, parallel_missing = 47, serial_missing = 41
[2026-06-16T00:51:38Z INFO  equality] DistL1 serial insertion : nb_found = 10000, nb_dist_equal = 1.00000e4, missing_count = 0
[2026-06-16T00:51:38Z INFO  equality] DistL1 comparison : parallel_found = 10000, serial_found = 10000, parallel_missing = 0, serial_missing = 0
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw] entering PointIndexation drop
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw] entering PointIndexation drop
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw] entering PointIndexation drop
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw]  drop sys time(s) 0 cpu time 0
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw]  drop sys time(s) 0 cpu time 0
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw]  drop sys time(s) 0 cpu time 0
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw] entering PointIndexation drop
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw] entering PointIndexation drop
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw] entering PointIndexation drop
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw]  drop sys time(s) 0 cpu time 0
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw]  drop sys time(s) 0 cpu time 0
test test_equality_float ... ok
test test_equality_cosine ... ok
[2026-06-16T00:51:38Z INFO  hnsw_rs::hnsw]  drop sys time(s) 0 cpu time 0
test test_equality_int ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 64.47s




```