### PR TITLE
Support `wasm32` behind a default-on `mmap` feature, and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  check:
+    name: cargo check (mmap on and off)
+    needs: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check with default features (mmap on)
+        run: cargo check
+      - name: Check without default features (mmap off)
+        run: cargo check --no-default-features
+
+  clippy:
+    name: clippy -D warnings
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Install HDF5 (dev-dependency build)
+        run: sudo apt-get update && sudo apt-get install -y libhdf5-dev pkg-config
+      - name: Clippy all targets (default features)
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Clippy lib without default features (mmap off)
+        run: cargo clippy --lib --no-default-features -- -D warnings
+
+  test:
+    name: cargo test
+    needs: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install HDF5 (dev-dependency build)
+        run: sudo apt-get update && sudo apt-get install -y libhdf5-dev pkg-config
+      - run: cargo test
+
+  wasm:
+    name: wasm32 build (default-features = false)
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+      - uses: Swatinem/rust-cache@v2
+      - name: Build for wasm32-wasip1 without default features
+        run: cargo build --lib --no-default-features --target wasm32-wasip1
+
+  audit:
+    name: cargo audit
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo generate-lockfile
+      - run: cargo audit
+
+  deny:
+    name: cargo deny
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - run: cargo deny check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rand = { version = "0.10" }
 lazy_static = { version = "1.4" }
 
 #
-mmap-rs = { version = "0.7" }
+mmap-rs = { version = "0.7", optional = true }
 #
 # decreasing order of log for debug build : (max_level_)trace debug info warn error off
 # decreasing order of log for release build (release_max_level_)  .. idem
@@ -103,7 +103,10 @@ itertools = {version = "0.14"}
 
 [features]
 
-default = []
+default = ["mmap"]
+
+# reload a dumped index by memory mapping its data file (native only, pulls in mmap-rs)
+mmap = ["dep:mmap-rs"]
 
 # feature for std simd on nightly
 stdsimd = ["anndists/stdsimd"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,26 @@
+[advisories]
+version = 2
+# Unmaintained transitive crates with no available fix. Vulnerability and yanked
+# detection stays fully active, only these reviewed advisories are waived.
+ignore = [
+    { id = "RUSTSEC-2025-0141", reason = "bincode 1.x is unmaintained but feature complete, transitive via the dump format, no safe upgrade exists" },
+]
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "Unicode-3.0",
+    "Zlib",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/examples/ann-glove25-angular.rs
+++ b/examples/ann-glove25-angular.rs
@@ -71,7 +71,7 @@ mod utils;
 use utils::*;
 
 pub fn main() {
-    let _ = env_logger::builder().is_test(true).try_init().unwrap();
+    env_logger::builder().is_test(true).try_init().unwrap();
     let parallel = true;
     //
     let fname = String::from("/home/jpboth/Data/ANN/glove-25-angular.hdf5");

--- a/src/api.rs
+++ b/src/api.rs
@@ -83,7 +83,7 @@ where
         dumpinit.flush()?;
         info!(
             "\n End of dump, directory : {:#?} file basename : {}\n",
-            path, &dumpname
+            path, dumpname
         );
         if res.is_ok() {
             Ok(dumpname)

--- a/src/datamap.rs
+++ b/src/datamap.rs
@@ -94,14 +94,14 @@ impl DataMap {
         //
         let meta = std::fs::metadata(&datapath);
         if meta.is_err() {
-            error!("Could not open file : {:?}", &datapath);
+            error!("Could not open file : {:?}", datapath);
             std::process::exit(1);
         }
         let fsize = meta.unwrap().len().try_into().unwrap();
         //
         let file_res = File::open(&datapath);
         if file_res.is_err() {
-            error!("Could not open file : {:?}", &datapath);
+            error!("Could not open file : {:?}", datapath);
             std::process::exit(1);
         }
         let file = file_res.unwrap();
@@ -111,12 +111,12 @@ impl DataMap {
         let mmap_opt = unsafe { mmap_opt.with_file(&file, offset) };
         let mapping_res = mmap_opt.map();
         if mapping_res.is_err() {
-            error!("Could not memory map : {:?}", &datapath);
+            error!("Could not memory map : {:?}", datapath);
             std::process::exit(1);
         }
         let mmap = mapping_res.unwrap();
         //
-        info!("Mmap done on file : {:?}", &datapath);
+        info!("Mmap done on file : {:?}", datapath);
         //
         // where are we in decoding mmap slice? at beginning
         //
@@ -321,7 +321,6 @@ impl DataMap {
 //=====================================================================================
 
 #[cfg(test)]
-
 mod tests {
 
     use super::*;
@@ -356,7 +355,7 @@ mod tests {
                 xsi = unif.sample(&mut rng);
                 data[j].push(xsi);
             }
-            debug!("j : {:?}, data : {:?} ", j, &data[j]);
+            debug!("j : {:?}, data : {:?} ", j, data[j]);
         }
         // define hnsw
         let ef_construct = 25;
@@ -393,9 +392,9 @@ mod tests {
             let id = unif.sample(&mut rng);
             let d = datamap.get_data::<f32>(&id);
             assert!(d.is_some());
-            if d.is_some() {
-                debug!("id = {}, v = {:?}", id, d.as_ref().unwrap());
-                assert_eq!(d.as_ref().unwrap(), &data[id]);
+            if let Some(v) = &d {
+                debug!("id = {}, v = {:?}", id, v);
+                assert_eq!(v, &data[id]);
             }
         }
         // test iterator from datamap
@@ -422,7 +421,7 @@ mod tests {
                 xsi = unif.sample(&mut rng);
                 data[j].push(xsi);
             }
-            debug!("j : {:?}, data : {:?} ", j, &data[j]);
+            debug!("j : {:?}, data : {:?} ", j, data[j]);
         }
         // define hnsw
         let ef_construct = 25;

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -126,7 +126,6 @@ impl<T: Clone + Send + Sync, D: Distance<T> + Send + Sync> From<&Hnsw<'_, T, D>>
 } // e,d of Fom implementation
 
 #[cfg(test)]
-
 mod tests {
 
     use super::*;

--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -6,7 +6,10 @@
 use rand::rngs::Xoshiro256PlusPlus;
 use serde::{Deserialize, Serialize};
 
+// cpu_time::ProcessTime is unavailable on wasm32-unknown-unknown and std time panics there at runtime
+#[cfg(not(target_arch = "wasm32"))]
 use cpu_time::ProcessTime;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::SystemTime;
 
 use std::cmp::Ordering;
@@ -412,7 +415,9 @@ pub struct PointIndexation<'b, T: Clone + Send + Sync> {
 
 impl<T: Clone + Send + Sync> Drop for PointIndexation<'_, T> {
     fn drop(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
         let cpu_start = ProcessTime::now();
+        #[cfg(not(target_arch = "wasm32"))]
         let sys_now = SystemTime::now();
         info!("entering PointIndexation drop");
         // clear_neighborhood. There are no point in neighborhoods that are not referenced directly in layers.
@@ -440,6 +445,7 @@ impl<T: Clone + Send + Sync> Drop for PointIndexation<'_, T> {
         debug!("clearing self.points_by_layer...");
         drop(self.points_by_layer.write());
         debug!("exiting PointIndexation drop");
+        #[cfg(not(target_arch = "wasm32"))]
         info!(
             " drop sys time(s) {:?} cpu time {:?}",
             sys_now.elapsed().unwrap().as_secs(),
@@ -1034,19 +1040,19 @@ impl<'b, T: Clone + Send + Sync, D: Distance<T> + Send + Sync> Hnsw<'b, T, D> {
                         );
                         candidate_points
                             .push(Arc::new(PointWithOrder::new(&e.point_ref, -e_dist_to_p)));
-                        if filter.is_none() {
-                            return_points.push(Arc::clone(&e_prime));
-                        } else {
+                        if let Some(f) = &filter {
                             let id: &usize = &e_prime.point_ref.get_origin_id();
-                            if filter.as_ref().unwrap().hnsw_filter(id) {
+                            if f.hnsw_filter(id) {
                                 if return_points.len() == 1 {
                                     let only_id = return_points.peek().unwrap().point_ref.origin_id;
-                                    if !filter.as_ref().unwrap().hnsw_filter(&only_id) {
+                                    if !f.hnsw_filter(&only_id) {
                                         return_points.clear()
                                     }
                                 }
                                 return_points.push(Arc::clone(&e_prime))
                             }
+                        } else {
+                            return_points.push(Arc::clone(&e_prime));
                         }
                         if return_points.len() > ef {
                             return_points.pop();
@@ -1753,7 +1759,6 @@ where
 } // end of check_reload
 
 #[cfg(test)]
-
 mod tests {
 
     use super::*;

--- a/src/hnswio.rs
+++ b/src/hnswio.rs
@@ -19,6 +19,8 @@
 use serde::{Serialize, de::DeserializeOwned};
 use std::sync::atomic::{AtomicUsize, Ordering};
 //
+// std time panics on wasm32-unknown-unknown, gate the diagnostic timing
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::SystemTime;
 
 // io
@@ -38,6 +40,7 @@ use std::any::type_name;
 use anndists::dist::distances::*;
 
 use self::hnsw::*;
+#[cfg(feature = "mmap")]
 use crate::datamap::*;
 use crate::hnsw;
 use log::{debug, error, info, trace};
@@ -160,7 +163,7 @@ impl DumpInit {
                 datapath.push(dataname);
                 let exist_res = std::fs::metadata(datapath.as_os_str());
                 if exist_res.is_ok() {
-                    let unique_basename = loop {
+                    loop {
                         let mut unique_basename;
                         let mut dataname: String;
                         let id: usize = rand::random_range(0..10000);
@@ -176,8 +179,7 @@ impl DumpInit {
                         if exist_res.is_err() {
                             break unique_basename;
                         }
-                    };
-                    unique_basename
+                    }
                 } else {
                     basename_default.to_string()
                 }
@@ -303,6 +305,7 @@ pub struct HnswIo {
     basename: String,
     /// options
     options: ReloadOptions,
+    #[cfg(feature = "mmap")]
     datamap: Option<DataMap>,
     /// for Hnswio to be async
     nb_point_loaded: Arc<AtomicUsize>,
@@ -319,6 +322,7 @@ impl HnswIo {
             dir: directory.to_path_buf(),
             basename: basename.to_string(),
             options: ReloadOptions::default(),
+            #[cfg(feature = "mmap")]
             datamap: None,
             nb_point_loaded: Arc::new(AtomicUsize::new(0)),
             initialized: true,
@@ -331,6 +335,7 @@ impl HnswIo {
             dir: directory.to_path_buf(),
             basename: basename.to_string(),
             options,
+            #[cfg(feature = "mmap")]
             datamap: None,
             nb_point_loaded: Arc::new(AtomicUsize::new(0)),
             initialized: true,
@@ -356,7 +361,10 @@ impl HnswIo {
         self.dir = directory.to_path_buf();
         self.basename = basename;
         self.options = options;
-        self.datamap = None;
+        #[cfg(feature = "mmap")]
+        {
+            self.datamap = None;
+        }
         //
         self.initialized = true;
         //
@@ -366,7 +374,7 @@ impl HnswIo {
     //
     fn init(&self) -> Result<LoadInit> {
         //
-        info!("reloading from basename : {}", &self.basename);
+        info!("reloading from basename : {}", self.basename);
         //
         let mut graphname = self.basename.clone();
         graphname.push_str(".hnsw.graph");
@@ -436,6 +444,7 @@ impl HnswIo {
     {
         //
         debug!("HnswIo::load_hnsw ");
+        #[cfg(not(target_arch = "wasm32"))]
         let start_t = SystemTime::now();
         //
         let init = self.init();
@@ -492,12 +501,21 @@ impl HnswIo {
         debug!("T type name in dump = {:?}", t_type);
         // Do we use mmap at reload
         if self.options.use_mmap().0 {
-            let datamap_res = DataMap::from_hnswdump::<T>(self.dir.as_path(), &self.basename);
-            if datamap_res.is_err() {
-                error!("load_hnsw could not initialize mmap")
-            } else {
-                info!("reload using mmap");
-                self.datamap = Some(datamap_res.unwrap());
+            #[cfg(feature = "mmap")]
+            {
+                match DataMap::from_hnswdump::<T>(self.dir.as_path(), &self.basename) {
+                    Result::Ok(datamap) => {
+                        info!("reload using mmap");
+                        self.datamap = Some(datamap);
+                    }
+                    Result::Err(_) => error!("load_hnsw could not initialize mmap"),
+                }
+            }
+            #[cfg(not(feature = "mmap"))]
+            {
+                return Err(anyhow!(
+                    "reload with mmap requested but hnsw_rs was built without the \"mmap\" feature"
+                ));
             }
         }
         // reloader can use datamap
@@ -518,8 +536,11 @@ impl HnswIo {
         };
         //
         debug!("load_hnsw completed");
-        let elapsed_t = start_t.elapsed().unwrap().as_secs() as f32;
-        info!("reload_hnsw : elapsed system time(s) {}", elapsed_t);
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let elapsed_t = start_t.elapsed().unwrap().as_secs() as f32;
+            info!("reload_hnsw : elapsed system time(s) {}", elapsed_t);
+        }
         Ok(hnsw)
     } // end of load_hnsw
 
@@ -820,11 +841,18 @@ impl HnswIo {
                 }
                 Point::<T>::new(v.unwrap(), origin_id, p_id)
             }
+            #[cfg(feature = "mmap")]
             true => {
                 skip_point_data(origin_id, data_in, descr)?; // keep cohrence between data file and graph file!
                 debug!("constructing point from datamap, dataid : {:?}", origin_id);
                 let s: Option<&'b [T]> = self.datamap.as_ref().unwrap().get_data::<T>(&origin_id);
                 Point::<T>::new_from_mmap(s.unwrap(), origin_id, p_id)
+            }
+            #[cfg(not(feature = "mmap"))]
+            true => {
+                return Err(anyhow!(
+                    "point reload with mmap requested but hnsw_rs was built without the \"mmap\" feature"
+                ));
             }
         };
         self.nb_point_loaded.fetch_add(1, Ordering::Relaxed);
@@ -1178,6 +1206,7 @@ where
 } // end of load_point_data
 
 // We need to maintain coherence in data and graph stream, so we read to keep in phase
+#[cfg(feature = "mmap")]
 fn skip_point_data(origin_id: usize, data_in: &mut dyn Read, _descr: &Description) -> Result<()> {
     //
     let mut it_slice = [0u8; std::mem::size_of::<u32>()];
@@ -1390,7 +1419,6 @@ impl<T: Serialize + DeserializeOwned + Clone + Sized + Send + Sync, D: Distance<
 //===============================================================================================================
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use env_logger::Builder;
 use lazy_static::lazy_static;
 
 pub mod api;
+#[cfg(feature = "mmap")]
 pub mod datamap;
 pub mod filter;
 pub mod flatten;

--- a/tests/deallocation_test.rs
+++ b/tests/deallocation_test.rs
@@ -26,7 +26,7 @@ fn main() {
         let s6 = [1.0, -1.0, 1.0];
         hnsw.insert_slice((&s6, 5));
 
-        if counter % 1_000_000 == 0 {
+        if counter.is_multiple_of(1_000_000) {
             println!("counter : {}", counter)
         }
         counter += 1;

--- a/tests/equality.rs
+++ b/tests/equality.rs
@@ -23,7 +23,7 @@ struct SearchStats {
     missing_ids: Vec<usize>,
 }
 
-fn report_search_results<T: std::fmt::Debug>(
+fn report_search_results(
     label: &str,
     data_neighbours: &[Vec<Neighbour>],
     epsil: f32,
@@ -128,7 +128,7 @@ fn test_equality_float() {
     assert_eq!(data_neighbours.len(), nbdata);
 
     let parallel_stats =
-        report_search_results::<f32>("DistL1 parallel insertion", &data_neighbours, epsil);
+        report_search_results("DistL1 parallel insertion", &data_neighbours, epsil);
 
     //
     // serial insertion
@@ -147,8 +147,7 @@ fn test_equality_float() {
     let data_neighbours = hns.parallel_search(&datas, search_k, search_ef);
     assert_eq!(data_neighbours.len(), nbdata);
 
-    let serial_stats =
-        report_search_results::<f32>("DistL1 serial insertion", &data_neighbours, epsil);
+    let serial_stats = report_search_results("DistL1 serial insertion", &data_neighbours, epsil);
 
     log::info!(
         "DistL1 comparison : parallel_found = {}, serial_found = {}, parallel_missing = {}, serial_missing = {}",
@@ -213,7 +212,7 @@ fn test_equality_cosine() {
     assert_eq!(data_neighbours.len(), nbdata);
 
     let parallel_stats =
-        report_search_results::<f32>("DistCosine parallel insertion", &data_neighbours, epsil);
+        report_search_results("DistCosine parallel insertion", &data_neighbours, epsil);
 
     //
     // serial insertion
@@ -238,7 +237,7 @@ fn test_equality_cosine() {
     assert_eq!(data_neighbours.len(), nbdata);
 
     let serial_stats =
-        report_search_results::<f32>("DistCosine serial insertion", &data_neighbours, epsil);
+        report_search_results("DistCosine serial insertion", &data_neighbours, epsil);
 
     log::info!(
         "DistCosine comparison : parallel_found = {}, serial_found = {}, parallel_missing = {}, serial_missing = {}",
@@ -302,7 +301,7 @@ fn test_equality_int() {
     assert_eq!(data_neighbours.len(), nbdata);
 
     let parallel_stats =
-        report_search_results::<u32>("DistJaccard parallel insertion", &data_neighbours, epsil);
+        report_search_results("DistJaccard parallel insertion", &data_neighbours, epsil);
 
     //
     // serial insertion
@@ -325,7 +324,7 @@ fn test_equality_int() {
     assert_eq!(data_neighbours.len(), nbdata);
 
     let serial_stats =
-        report_search_results::<u32>("DistJaccard serial insertion", &data_neighbours, epsil);
+        report_search_results("DistJaccard serial insertion", &data_neighbours, epsil);
 
     log::info!(
         "DistJaccard comparison : parallel_found = {}, serial_found = {}, parallel_missing = {}, serial_missing = {}",

--- a/tests/filtertest.rs
+++ b/tests/filtertest.rs
@@ -135,10 +135,9 @@ fn filter_levenstein() {
     // how many neighbours in res are in filter_vec_res
     let mut nb_found: usize = 0;
     for n in &res {
-        let found = filter_vec_res.iter().find(|&&m| m.d_id == n.d_id);
-        if found.is_some() {
+        if let Some(found) = filter_vec_res.iter().find(|&&m| m.d_id == n.d_id) {
             nb_found += 1;
-            assert_eq!(n.distance, found.unwrap().distance);
+            assert_eq!(n.distance, found.distance);
         }
     }
     println!(" recall : {}", nb_found as f32 / res.len() as f32);
@@ -205,10 +204,9 @@ fn filter_l2() {
     // how many neighbours in res are in filter_vec_res and what is the distance gap
     let mut nb_found: usize = 0;
     for n in &res {
-        let found = filter_vec_res.iter().find(|&&m| m.d_id == n.d_id);
-        if found.is_some() {
+        if let Some(found) = filter_vec_res.iter().find(|&&m| m.d_id == n.d_id) {
             nb_found += 1;
-            assert!((1. - n.distance / found.unwrap().distance).abs() < 1.0e-5);
+            assert!((1. - n.distance / found.distance).abs() < 1.0e-5);
         }
     }
     println!(" recall : {}", nb_found as f32 / res.len() as f32);
@@ -227,7 +225,7 @@ fn filter_villsnow() {
     log_init_test();
     //
     let grid_size = 100;
-    let mut hnsw = Hnsw::<f64, DistL2>::new(4, grid_size * grid_size, 16, 100, DistL2::default());
+    let mut hnsw = Hnsw::<f64, DistL2>::new(4, grid_size * grid_size, 16, 100, DistL2);
     let mut points = HashMap::new();
 
     {
@@ -245,7 +243,7 @@ fn filter_villsnow() {
     {
         println!("first case");
         // first case
-        let filter = |id: &usize| DistL2::default().eval(&points[id], &[1.0, 1.0]) < 1e-2;
+        let filter = |id: &usize| DistL2.eval(&points[id], &[1.0, 1.0]) < 1e-2;
         dbg!(points.keys().filter(|x| filter(x)).count()); // -> 1
 
         let hit = hnsw.search_filter(&[0.0, 0.0], 10, 4, Some(&filter));


### PR DESCRIPTION
`mmap-rs` was the only thing stopping `hnsw_rs` from building for `wasm32-unknown-unknown`, which it needs to serve as a kNN backend on the web. It is now an optional dependency behind a default-on `mmap` feature, so native users are unaffected and the release stays semver compatible, while wasm consumers depend with `default-features = false`. The `datamap` module and the reload-by-memory-map path are gated behind it, while the dump path and in-memory reload still work without it. The `cpu-time` and `std::time` calls in `Drop` and `load_hnsw` (both only `info!` logging) are gated off on wasm, where they do not compile or panic. `rayon` is untouched so the threaded build keeps working.

This also adds the repository's first CI, a `fmt`, `check`, `clippy`, `test`, `wasm`, `audit`, `deny` graph. The `wasm` job builds for `wasm32-wasip1` with `--no-default-features`. Making `cargo clippy -- -D warnings` pass required clearing the existing mechanical clippy warnings across the crate, the tests, and one example (behavior preserving, re-checked against the suite). `deny.toml` waives only `RUSTSEC-2025-0141` (`bincode` 1.x unmaintained, no fix available).

Consumers targeting `wasm32-unknown-unknown` still wire `getrandom`'s `wasm_js` backend themselves, since the randomness source on bare wasm belongs to the final binary.
